### PR TITLE
Fixes undefined value in datepicker after quickadded set

### DIFF
--- a/resources/assets/js/components/ExerciseCard.js
+++ b/resources/assets/js/components/ExerciseCard.js
@@ -118,7 +118,7 @@ export default class ExerciseCard extends Component {
         //Clear Data
         this.setState({newData: {
                 warmup: false,
-                date: undefined,
+                date: new Date(),
                 weight: 20,
                 reps: 5,
                 config: {


### PR DESCRIPTION
Fixes #42
Changed resetForm() to set `date` to `new Date()` instead of `undefined`