### PR TITLE
Reduce the amount of Bootstrap components in exercise cards

### DIFF
--- a/resources/assets/js/components/ExerciseCard.js
+++ b/resources/assets/js/components/ExerciseCard.js
@@ -221,112 +221,74 @@ export default class ExerciseCard extends Component {
                             </a>
                         </span>
                     </div>
-                        <Row className="card-body">
-                            <Collapse isOpened={this.state.showAdder}>
-                                <Row>
-                                    <Col>
-                                        <DatePicker selected={this.state.newData.date} onChange={this.handleDateChange}/>
-                                    </Col>
-                                </Row>
-                                <Row>
-                                    <Col lg={3} md={6}>
-                                        <Row>
-                                            <Col>
-                                                Warmup
-                                            </Col>
-                                        </Row>
-                                        <Row>
-                                            <Col>
-                                                <Button
-                                                    variant={this.state.newData.config.warmup ? "secondary" : "outline-secondary"}
-                                                    type="radio"
-                                                    size="sm"
-                                                    onClick={() => this.changeWarmup(true)}
-
-                                                >
-                                                    Warmup
-                                                </Button>
-                                            </Col>
-                                        </Row>
-                                        <Row>
-                                            <Col>
-                                                <Button
-                                                    variant={this.state.newData.config.warmup ? "outline-success" : "success"}
-                                                    type="radio"
-                                                    size="sm"
-                                                    onClick={() => this.changeWarmup(false)}
-                                                >
-                                                    Real
-                                                </Button>
-                                            </Col>
-                                        </Row>
-                                    </Col>
-                                    <Col lg={3} md={6}>
-                                        Weight
-                                        <Row>
-                                            <Col>
-                                                <InputGroup>
-                                                    <InputGroup.Prepend>
-                                                        <Button size="sm" variant="warning" onClick={() => {this.changeWeight(-5)}}>-5</Button>
-                                                    </InputGroup.Prepend>
-                                                   <FormControl size="sm" name="weight" type="number" value={this.state.newData.weight} onChange={this.handleQuickAddChange}/>
-                                                    <InputGroup.Append>
-                                                        <Button size="sm" variant="success" onClick={() => {this.changeWeight(10)}}>10</Button>
-                                                    </InputGroup.Append>
-                                                </InputGroup>
-                                            </Col>
-                                        </Row>
-                                        <Row>
-                                            <Col>
-                                                <Button
-                                                    variant={this.state.newData.config.lb ? "info" : "outline-info"}
-                                                    size="sm"
-                                                    onClick={() => this.changeWeightFormatToLb(true)}
-                                                >
-                                                    LB
-                                                </Button>
-                                                <Button
-                                                    variant={this.state.newData.config.lb ? "outline-info" : "info"}
-                                                    size="sm"
-                                                    onClick={() => this.changeWeightFormatToLb(false)}
-                                                >
-                                                    KG
-                                                </Button>
-                                            </Col>
-                                        </Row>
-                                    </Col>
-                                    <Col lg={3} md={6}>
-                                        Reps
-                                        <Row>
-                                            <Col>
-                                                <InputGroup className="mb-1">
-                                                    <InputGroup.Prepend>
-                                                        <Button size="sm" variant="danger" onClick={() => {this.changeReps(-1)}}>-</Button>
-                                                    </InputGroup.Prepend>
-                                                        <FormControl name="reps" type="number" size="sm" value={this.state.newData.reps} onChange={this.handleQuickAddChange}/>
-                                                    <InputGroup.Append>
-                                                        <Button size="sm" variant="success" onClick={() => {this.changeReps(1)}}>+</Button>
-                                                    </InputGroup.Append>
-                                                </InputGroup>
-                                            </Col>
-                                        </Row>
-                                    </Col>
-                                    <Col lg={3} md={6}>
-                                        Save
-                                        <Row>
-                                            <Col>
-                                                <Button variant="success" size="sm" onClick={() => this.saveSetToCard()}>
-                                                    <img src="icons/baseline_check_circle_outline_white_18dp.png"/>
-                                                </Button>
-                                                <Button variant="danger" size="sm" onClick={() => this.resetForm()}>
-                                                    <img src="icons/baseline_close_white_18dp.png"/>
-                                                </Button>
-                                            </Col>
-                                        </Row>
-                                    </Col>
-                                </Row>
-                            </Collapse>
-                        </Row>
+                    <Row className="card-body">
+                        <Collapse className="quickadder-collapse" isOpened={this.state.showAdder}>
+                            <div className="quickadder-date">
+                                <span className="date-title">Date:</span>
+                                <DatePicker selected={this.state.newData.date} onChange={this.handleDateChange}/>
+                            </div>
+                            <div className="quickadder-values">
+                                <div className="warmup">
+                                    <span>Warmup</span>
+                                    <Button variant={this.state.newData.config.warmup ? "secondary" : "outline-secondary"}
+                                            type="radio"
+                                            size="sm"
+                                            onClick={() => this.changeWarmup(true)}>
+                                        Warmup
+                                    </Button>
+                                    <Button variant={this.state.newData.config.warmup ? "outline-success" : "success"}
+                                            type="radio"
+                                            size="sm"
+                                            onClick={() => this.changeWarmup(false)}>
+                                        Real
+                                    </Button>
+                                </div>
+                                <div className="weight">
+                                    <span>Weight</span>
+                                    <InputGroup>
+                                        <InputGroup.Prepend>
+                                            <Button size="sm" variant="warning" onClick={() => {this.changeWeight(-5)}}>-5</Button>
+                                        </InputGroup.Prepend>
+                                        <FormControl size="sm" className="number-field" name="weight" value={this.state.newData.weight} onChange={this.handleQuickAddChange}/>
+                                        <InputGroup.Append>
+                                            <Button size="sm" variant="success" onClick={() => {this.changeWeight(10)}}>10</Button>
+                                        </InputGroup.Append>
+                                    </InputGroup>
+                                    <Button variant={this.state.newData.config.lb ? "info" : "outline-info"}
+                                            size="sm"
+                                            onClick={() => this.changeWeightFormatToLb(true)}>
+                                        LB
+                                    </Button>
+                                    <Button variant={this.state.newData.config.lb ? "outline-info" : "info"}
+                                            size="sm"
+                                            onClick={() => this.changeWeightFormatToLb(false)}>
+                                        KG
+                                    </Button>
+                                </div>
+                                <div className="reps">
+                                    <span>Reps</span>
+                                    <InputGroup className="mb-1">
+                                        <InputGroup.Prepend>
+                                            <Button size="sm" variant="danger" onClick={() => {this.changeReps(-1)}}>-</Button>
+                                        </InputGroup.Prepend>
+                                        <FormControl name="reps" size="sm" className="number-field" value={this.state.newData.reps} onChange={this.handleQuickAddChange}/>
+                                        <InputGroup.Append>
+                                            <Button size="sm" variant="success" onClick={() => {this.changeReps(1)}}>+</Button>
+                                        </InputGroup.Append>
+                                    </InputGroup>
+                                </div>
+                                <div className="save">
+                                    <span>Save</span>
+                                    <Button variant="success" size="sm" onClick={() => this.saveSetToCard()}>
+                                        <img src="icons/baseline_check_circle_outline_white_18dp.png"/>
+                                    </Button>
+                                    <Button variant="danger" size="sm" onClick={() => this.resetForm()}>
+                                        <img src="icons/baseline_close_white_18dp.png"/>
+                                    </Button>
+                                </div>
+                            </div>
+                        </Collapse>
+                    </Row>
                     <Collapse isOpened={!this.state.collapsed}>
                         <Row>
                             <Col>

--- a/resources/assets/js/components/ExerciseCard.js
+++ b/resources/assets/js/components/ExerciseCard.js
@@ -221,7 +221,7 @@ export default class ExerciseCard extends Component {
                             </a>
                         </span>
                     </div>
-                    <Row className="card-body">
+                    <div className="card-body">
                         <Collapse className="quickadder-collapse" isOpened={this.state.showAdder}>
                             <div className="quickadder-date">
                                 <span className="date-title">Date:</span>
@@ -288,15 +288,11 @@ export default class ExerciseCard extends Component {
                                 </div>
                             </div>
                         </Collapse>
-                    </Row>
-                    <Collapse isOpened={!this.state.collapsed}>
-                        <Row>
-                            <Col>
+                        <Collapse isOpened={!this.state.collapsed}>
+                            <div className="loader">
                                 <ReactLoading className="centered-loader" type="spin" color="#949494" height="10%" width="10%" hidden={!this.state.loading} />
-                            </Col>
-                        </Row>
-                        <Row>
-                            <Col className="justify-content-center">
+                            </div>
+                            <div className="card-data">
                                 <Table responsive>
                                     <thead>
                                     <tr>
@@ -307,15 +303,15 @@ export default class ExerciseCard extends Component {
                                     </tr>
                                     </thead>
                                     <tbody>
-                                    {this.state.sets}
+                                        {this.state.sets}
                                     </tbody>
                                 </Table>
-                            </Col>
-                        </Row>
-                    </Collapse>
+                            </div>
+                        </Collapse>
+                    </div>
                 </div>
                 <br />
-            </Col>
+            </div>
         );
     }
 }

--- a/resources/assets/js/components/ExerciseCard.js
+++ b/resources/assets/js/components/ExerciseCard.js
@@ -205,14 +205,15 @@ export default class ExerciseCard extends Component {
 
     render() {
         return(
-            <Col md={6}>
+            <div className="card-container">
                 <div className="card text-center">
                     <div className="card-header">
-                        <span className="maximise_card">
-                            <img src="icons/baseline_keyboard_arrow_down_black_18dp.png" onClick={() => this.toggleCollapse()}/>
+                        <span className="maximise-card">
+                            <i className="fas fa-plus-circle" hidden={!this.state.collapsed} onClick={() => this.toggleCollapse()}></i>
+                            <i className="fas fa-minus-circle" hidden={this.state.collapsed} onClick={() => this.toggleCollapse()}></i>
                         </span>
                         <span className="h3"><b>{this.props.exercise.name}</b></span>
-                        <span className="exercise_icons">
+                        <span className="exercise-icons">
                             <button className="btn btn-primary" title="Add Workout" id="quckAddSet" onClick={() => this.toggleQuickAdder()}>
                                 <img src="icons/baseline_add_black_18dp.png" alt="Add Workout" />
                             </button>

--- a/resources/assets/sass/_dashboard.scss
+++ b/resources/assets/sass/_dashboard.scss
@@ -3,12 +3,13 @@ $dashboard-top-panel-height: 80px;
 $dashboard-side-panel-width: 20%;
 $dashboard-content-width: 80%;
 
-.exercise_icons{
+.exercise-icons{
   float: right;
 }
 
-.maximise_card{
+.maximise-card{
   float: left;
+  font-size: 2em;
 }
 
 .centered-loader{

--- a/resources/assets/sass/_dashboard.scss
+++ b/resources/assets/sass/_dashboard.scss
@@ -46,9 +46,6 @@ $dashboard-content-width: 80%;
 
 .dashboard-container{
   padding: 15px 15px 0px 15px;
-  display: flex;
-  justify-content: space-around;
-  flex-wrap: wrap;
   height: 100%;
   display: flex;
   flex-wrap: wrap;

--- a/resources/assets/sass/_dashboard.scss
+++ b/resources/assets/sass/_dashboard.scss
@@ -45,14 +45,16 @@ $dashboard-content-width: 80%;
 }
 
 .dashboard-container{
-
   padding: 15px 15px 0px 15px;
   display: flex;
   justify-content: space-around;
   flex-wrap: wrap;
   height: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+
   @include media-breakpoint-up(md) {
-    width: $dashboard-content-width;
     margin-top: $dashboard-top-panel-height;
     margin-left: $dashboard-side-panel-width;
   }
@@ -61,6 +63,7 @@ $dashboard-content-width: 80%;
     margin-left: 0px;
   }
 }
+
 
 .dashboard-side-panel{
   background-color: $background-color - 50;

--- a/resources/assets/sass/_quickadder.scss
+++ b/resources/assets/sass/_quickadder.scss
@@ -1,0 +1,25 @@
+.quickadder-collapse{
+  width: 100%;
+}
+
+.quickadder-date{
+  span{
+    margin-right: 5px;
+  }
+}
+
+.quickadder-values{
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+
+  .warmup, .warmup, .reps, .save{
+    display: flex;
+    flex-direction: column;
+
+    .number-field{
+      max-width: 8em;
+      min-width: 4em;
+    }
+  }
+}

--- a/resources/assets/sass/_quickadder.scss
+++ b/resources/assets/sass/_quickadder.scss
@@ -1,5 +1,6 @@
 .quickadder-collapse{
   width: 100%;
+  margin-bottom: 15px;
 }
 
 .quickadder-date{

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -8,6 +8,7 @@
 @import "dashboard";
 @import "mobile";
 @import "login";
+@import "_quickadder";
 
 @import "pages/_exercises";
 @import "pages/_sets";

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -12,6 +12,7 @@
     <!-- Styles -->
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
     <link href="{{ asset('css/bootstrap.min.css') }}" rel="stylesheet">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
 </head>
 <body>
 


### PR DESCRIPTION
There is too much row/column nesting in the exercise cards, making the code hard to decipher.
Reduced the use of rows/columns and instead used SCSS (Flexbox, divs)
Also added the fontawesome library (https://fontawesome.com/) for future use and replaced the collapse card icons.